### PR TITLE
Parse codeblock language

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "markdown-to-html"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "nom",
 ]
@@ -17,23 +17,16 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "minimal-lexical"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c835948974f68e0bd58636fc6c5b1fbff7b297e3046f11b3b3c18bbac012c6d"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "nom"
-version = "7.0.0"
+version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffd9d26838a953b4af82cbeb9f1592c6798916983959be223a7124e992742c1"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
- "version_check",
 ]
-
-[[package]]
-name = "version_check"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nom = "7.0.0"
+nom = "7.1.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub enum Markdown {
     OrderedList(Vec<MarkdownText>),
     UnorderedList(Vec<MarkdownText>),
     Line(MarkdownText),
-    Codeblock(String),
+    Codeblock(String, String),
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -481,7 +481,10 @@ mod tests {
             ))
         );
         assert_eq!(
-            parse_markdown_inline("here is some plaintext \n*but what if we italicize?"),
+            parse_markdown_inline(
+                r#"here is some plaintext 
+*but what if we italicize?"#
+            ),
             Ok((
                 "\n*but what if we italicize?",
                 MarkdownInline::Plaintext(String::from("here is some plaintext "))
@@ -681,7 +684,11 @@ mod tests {
             ))
         );
         assert_eq!(
-            parse_unordered_list_element("- this is an element\n- this is another element\n"),
+            parse_unordered_list_element(
+                r#"- this is an element
+- this is another element
+"#
+            ),
             Ok((
                 "- this is another element\n",
                 vec![MarkdownInline::Plaintext(String::from(
@@ -739,7 +746,11 @@ mod tests {
             ))
         );
         assert_eq!(
-            parse_unordered_list("- this is an element\n- here is another\n"),
+            parse_unordered_list(
+                r#"- this is an element
+- here is another
+"#
+            ),
             Ok((
                 "",
                 vec![
@@ -802,7 +813,11 @@ mod tests {
             ))
         );
         assert_eq!(
-            parse_ordered_list_element("1. this is an element\n1. here is another\n"),
+            parse_ordered_list_element(
+                r#"1. this is an element
+1. here is another
+"#
+            ),
             Ok((
                 "1. here is another\n",
                 vec![MarkdownInline::Plaintext(String::from(
@@ -867,7 +882,11 @@ mod tests {
             }))
         );
         assert_eq!(
-            parse_ordered_list("1. this is an element\n2. here is another\n"),
+            parse_ordered_list(
+                r#"1. this is an element
+2. here is another
+"#
+            ),
             Ok((
                 "",
                 vec![
@@ -883,12 +902,38 @@ mod tests {
     #[test]
     fn test_parse_codeblock() {
         assert_eq!(
-            parse_code_block("```bash\n pip install foobar\n```"),
-            Ok(("", "bash\n pip install foobar\n"))
+            parse_code_block(
+                r#"```bash
+pip install foobar
+```"#
+            ),
+            Ok((
+                "",
+                r#"bash
+pip install foobar
+"#
+            ))
         );
         assert_eq!(
-            parse_code_block("```python\nimport foobar\n\nfoobar.pluralize('word') # returns 'words'\nfoobar.pluralize('goose') # returns 'geese'\nfoobar.singularize('phenomena') # returns 'phenomenon'\n```"),
-            Ok(("", "python\nimport foobar\n\nfoobar.pluralize('word') # returns 'words'\nfoobar.pluralize('goose') # returns 'geese'\nfoobar.singularize('phenomena') # returns 'phenomenon'\n"))
+            parse_code_block(
+                r#"```python
+import foobar
+
+foobar.pluralize('word') # returns 'words'
+foobar.pluralize('goose') # returns 'geese'
+foobar.singularize('phenomena') # returns 'phenomenon'
+```"#
+            ),
+            Ok((
+                "",
+                r#"python
+import foobar
+
+foobar.pluralize('word') # returns 'words'
+foobar.pluralize('goose') # returns 'geese'
+foobar.singularize('phenomena') # returns 'phenomenon'
+"#
+            ))
         );
         // assert_eq!(
         // 	parse_code_block("```bash\n pip `install` foobar\n```"),
@@ -899,13 +944,29 @@ mod tests {
     #[test]
     fn test_parse_markdown() {
         assert_eq!(
-            parse_markdown("# Foobar\n\nFoobar is a Python library for dealing with word pluralization.\n\n```bash\n pip install foobar\n```\n## Installation\n\nUse the package manager [pip](https://pip.pypa.io/en/stable/) to install foobar.\n```python\nimport foobar\n\nfoobar.pluralize('word') # returns 'words'\nfoobar.pluralize('goose') # returns 'geese'\nfoobar.singularize('phenomena') # returns 'phenomenon'\n```"),
+            parse_markdown(r#"# Foobar
+
+Foobar is a Python library for dealing with word pluralization.
+
+```bash
+pip install foobar
+```
+## Installation
+
+Use the package manager [pip](https://pip.pypa.io/en/stable/) to install foobar.
+```python
+import foobar
+
+foobar.pluralize('word') # returns 'words'
+foobar.pluralize('goose') # returns 'geese'
+foobar.singularize('phenomena') # returns 'phenomenon'
+```"#),
             Ok(("", vec![
                 Markdown::Heading(1, vec![MarkdownInline::Plaintext(String::from("Foobar"))]),
                 Markdown::Line(vec![]),
                 Markdown::Line(vec![MarkdownInline::Plaintext(String::from("Foobar is a Python library for dealing with word pluralization."))]),
                 Markdown::Line(vec![]),
-                Markdown::Codeblock(String::from("bash\n pip install foobar\n")),
+                Markdown::Codeblock(String::from("bash\npip install foobar\n")),
                 Markdown::Line(vec![]),
                 Markdown::Heading(2, vec![MarkdownInline::Plaintext(String::from("Installation"))]),
                 Markdown::Line(vec![]),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -141,7 +141,7 @@ fn parse_code_block_body(i: &str) -> IResult<&str, &str> {
 fn parse_code_block_lang(i: &str) -> IResult<&str, String> {
     alt((
         preceded(tag("```"), parse_plaintext),
-        map(tag("```"), |_| "".to_string()),
+        map(tag("```"), |_| "__UNKNOWN__".to_string()),
     ))(i)
 }
 
@@ -969,7 +969,7 @@ pip install foobar
             Ok((
                 "",
                 (
-                    String::from(""),
+                    String::from("__UNKNOWN__"),
                     r#"pip install foobar
 "#
                 )

--- a/src/translator.rs
+++ b/src/translator.rs
@@ -8,7 +8,9 @@ pub fn translate(md: Vec<Markdown>) -> String {
             Markdown::Heading(size, line) => translate_header(*size, line.to_vec()),
             Markdown::UnorderedList(lines) => translate_unordered_list(lines.to_vec()),
             Markdown::OrderedList(lines) => translate_ordered_list(lines.to_vec()),
-            Markdown::Codeblock(code) => translate_codeblock(code.to_string()),
+            Markdown::Codeblock(lang, code) => {
+                translate_codeblock(lang.to_string(), code.to_string())
+            }
             Markdown::Line(line) => translate_line(line.to_vec()),
         })
         .collect::<Vec<String>>()
@@ -55,12 +57,12 @@ fn translate_ordered_list(lines: Vec<MarkdownText>) -> String {
     format!("<ol>{}</ol>", translate_list_elements(lines.to_vec()))
 }
 
-fn translate_code(code: MarkdownText) -> String {
-    format!("<code>{}</code>", translate_text(code))
-}
+// fn translate_code(code: MarkdownText) -> String {
+//     format!("<code>{}</code>", translate_text(code))
+// }
 
-fn translate_codeblock(code: String) -> String {
-    format!("<pre><code>{}</code></pre>", code)
+fn translate_codeblock(lang: String, code: String) -> String {
+    format!("<pre><code class=\"lang-{}\">{}</code></pre>", lang, code)
 }
 
 fn translate_line(text: MarkdownText) -> String {
@@ -201,9 +203,28 @@ mod tests {
     #[test]
     fn test_translate_codeblock() {
         assert_eq!(
-			translate_codeblock(String::from("python\nimport foobar\n\nfoobar.pluralize(\'word\') # returns \'words\'\nfoobar.pluralize(\'goose\') # returns \'geese\'\nfoobar.singularize(\'phenomena\') # returns \'phenomenon\'\n")),
-			String::from("<pre><code>python\nimport foobar\n\nfoobar.pluralize(\'word\') # returns \'words\'\nfoobar.pluralize(\'goose\') # returns \'geese\'\nfoobar.singularize(\'phenomena\') # returns \'phenomenon\'\n</code></pre>")
-		);
+            translate_codeblock(
+                String::from("python"),
+                String::from(
+                    r#"
+import foobar
+
+foobar.pluralize(\'word\') # returns \'words\'
+foobar.pluralize(\'goose\') # returns \'geese\'
+foobar.singularize(\'phenomena\') # returns \'phenomenon\'
+"#
+                )
+            ),
+            String::from(
+                r#"<pre><code class="lang-python">
+import foobar
+
+foobar.pluralize(\'word\') # returns \'words\'
+foobar.pluralize(\'goose\') # returns \'geese\'
+foobar.singularize(\'phenomena\') # returns \'phenomenon\'
+</code></pre>"#
+            )
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

Adds the support to handle the language from a codeblock

\`\`\`js
const hello = 'world';
\`\`\`

Will result in a tuple

```rust
(String::from("js"), "const hello = 'world';")
```

And when a codeblock doesn't include it, like so

\`\`\`
const hello = 'world';
\`\`\`

Results in

```rust
(String::from("__UNKNOWN__"), "const hello = 'world';")
```

### HTML

The parsed HTML of a codeblock would look like so


```
<pre><code class="lang-js">const hello = 'world';</code></pre>


<pre><code class="lang-__UNKNOWN__">const hello = 'world';</code></pre>
```

Which then it would make it quite easy to add proper styles to the language using tools like [highlight.js](https://highlightjs.org/)

## Before merging

At this point, the language is a simple `String`, it probably should be an enum instead, but then this library would need to know about the existing languages, but the result would be a better experience, because then users could use the language as `js` or `javascript` and both result in an enum like `Language::JavaScript`. But as I said, it's a tradeoff, it would require more effort to maintain.

## Additional changes

Looks like there was a signature by `nom`, when I forked the repo it was failing to compile because the tests were failing. I fixed them and then decided to update `nom` to its latest version (a bump in minor and patch).

Additionally, I replaced many of the strings that contain a `\n` into a multi-line string, which makes it easy to read.